### PR TITLE
Remove apply method in QingStorException

### DIFF
--- a/src/main/scala/com/qingstor/sdk/exception/QingStorException.scala
+++ b/src/main/scala/com/qingstor/sdk/exception/QingStorException.scala
@@ -35,7 +35,3 @@ class QingStorException(error: ErrorMessage) extends Throwable {
     "QingStor exception:\n\t%s".format(errorMessage)
   }
 }
-
-object QingStorException {
-  def apply(error: ErrorMessage): QingStorException = new QingStorException(error)
-}

--- a/src/main/scala/com/qingstor/sdk/request/ResponseUnpacker.scala
+++ b/src/main/scala/com/qingstor/sdk/request/ResponseUnpacker.scala
@@ -44,7 +44,7 @@ object ResponseUnpacker {
           case Left(failure) =>
             val requestID = parseRequestID(response).getOrElse("Can't parse request_id")
             val error = ErrorMessage(requestID = requestID, message = Some(failure.message))
-            throw QingStorException(error)
+            throw new QingStorException(error)
           case Right(t) => t
         }
         setupStatusCodeAndRequestID(output, response)
@@ -86,7 +86,7 @@ object ResponseUnpacker {
             val requestID = parseRequestID(response).getOrElse("Can't parse request_id")
             val error = ErrorMessage(requestID = requestID, message = Some(failure.message),
               statusCode = Some(response.status.intValue()))
-            throw QingStorException(error)
+            throw new QingStorException(error)
           case Right(errorMessage) =>
             errorMessage.statusCode = Some(response.status.intValue())
             errorMessage

--- a/src/main/scala/com/qingstor/sdk/service/Bucket.scala
+++ b/src/main/scala/com/qingstor/sdk/service/Bucket.scala
@@ -33,7 +33,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[DeleteBucketOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -63,7 +63,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[DeleteBucketCORSOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -94,7 +94,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithoutElements[DeleteBucketExternalMirrorOutput](futureResponse,
                                                                operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -126,7 +126,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithoutElements[DeleteBucketPolicyOutput](futureResponse,
                                                        operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -157,7 +157,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithElements[DeleteMultipleObjectsOutput](futureResponse,
                                                        operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -187,7 +187,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithElements[GetBucketACLOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -216,7 +216,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithElements[GetBucketCORSOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -247,7 +247,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithElements[GetBucketExternalMirrorOutput](futureResponse,
                                                          operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -277,7 +277,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithElements[GetBucketPolicyOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -307,7 +307,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithElements[GetBucketStatisticsOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -336,7 +336,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[HeadBucketOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -367,7 +367,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithElements[ListMultipartUploadsOutput](futureResponse,
                                                       operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -397,7 +397,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithElements[ListObjectsOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -426,7 +426,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[PutBucketOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -455,7 +455,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[PutBucketACLOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -484,7 +484,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[PutBucketCORSOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -515,7 +515,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithoutElements[PutBucketExternalMirrorOutput](futureResponse,
                                                             operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -545,7 +545,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[PutBucketPolicyOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -577,7 +577,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithoutElements[AbortMultipartUploadOutput](futureResponse,
                                                          operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -612,7 +612,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithoutElements[CompleteMultipartUploadOutput](futureResponse,
                                                             operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -645,7 +645,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[DeleteObjectOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -677,7 +677,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[GetObjectOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -711,7 +711,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[HeadObjectOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -744,7 +744,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
       .unpackWithElements[InitiateMultipartUploadOutput](futureResponse,
                                                          operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -777,7 +777,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithElements[ListMultipartOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -809,7 +809,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[OptionsObjectOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -841,7 +841,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[PutObjectOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }
@@ -873,7 +873,7 @@ class Bucket(_config: QSConfig, _bucketName: String, _zone: String) {
     ResponseUnpacker
       .unpackWithoutElements[UploadMultipartOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }

--- a/src/main/scala/com/qingstor/sdk/service/QingStor.scala
+++ b/src/main/scala/com/qingstor/sdk/service/QingStor.scala
@@ -28,7 +28,7 @@ class QingStor(_config: QSConfig) {
     ResponseUnpacker
       .unpackWithElements[ListBucketsOutput](futureResponse, operation)
       .map({
-        case Left(errorMessage) => throw QingStorException(errorMessage)
+        case Left(errorMessage) => throw new QingStorException(errorMessage)
         case Right(output) => output
       })
   }

--- a/template/shared.tmpl
+++ b/template/shared.tmpl
@@ -189,7 +189,7 @@
         val operation = request.operation
         val futureResponse = request.send()
         ResponseUnpacker.unpackWith{{- if not $hasResponseElements -}}out{{- end -}}Elements[{{- $opID -}}Output](futureResponse, operation).map({
-            case Left(errorMessage) => throw QingStorException(errorMessage)
+            case Left(errorMessage) => throw new QingStorException(errorMessage)
             case Right(output) => output
         })
     }


### PR DESCRIPTION
It's ambiguous for this apply method to appear at the top of stack trace, like this:
>com.qingstor.sdk.exception.QingStorException: QingStor exception:
>	request_id: 7165b318411a11e7acab525464ed00d9, status_code: 400
>
>	at com.qingstor.sdk.exception.QingStorException$.apply(QingStorException.scala:40)
>	at com.qingstor.sdk.service.QingStor.$anonfun$listBuckets$1(QingStor.scala:31)
>	at scala.util.Success.$anonfun$map$1(Try.scala:251)

Signed-off-by: XieQirong <cheerx1994@163.com>